### PR TITLE
Add typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+import React, {Component} from 'react';
+
+interface Props {
+  readonly children?: string;
+  readonly date?: number | string;
+  readonly format?: string;
+  readonly interval?: number;
+  readonly ticking?: boolean;
+  readonly timezone?: string;
+  readonly filter?: () => void;
+  readonly onChange?: () => void;
+}
+
+declare class SimpleSelect extends Component<Props, any> {}
+
+export default SimpleSelect;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "React Live Clock",
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "config": {
     "component": "ReactLiveClock"
   },


### PR DESCRIPTION
Add typescript definition based on `ReactLiveClock.propTypes` in `Component.js`.