### PR TITLE
fix: missing `blinking` in type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ interface Props {
   readonly filter?: () => void;
   readonly format?: string;
   readonly interval?: number;
+  readonly blinking?: boolean | string;
   readonly locale?: string;
   readonly onChange?: () => void;
   readonly style?: CSSProperties;


### PR DESCRIPTION
Fix to failed type check in typescript when use `blinking` option.
I append type definition for `blinking` to `index.d.ts`.